### PR TITLE
build: update Dockerfile to meet some best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base build
-FROM node:8.9.4 as base
+FROM node:8.9.4 AS base
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -12,6 +12,7 @@ RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc && \
 
 # second build
 FROM node:8.9.4
-COPY --from=base . .
+WORKDIR /usr/src/app
+COPY --from=base /usr/src/app /usr/src/app
 EXPOSE 4000
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-# specify the node base image with your desired version node:<version>
-FROM node:8.9.4
+# base build
+FROM node:8.9.4 as base
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . /usr/src/app
-
 ARG NPM_TOKEN
 
-RUN echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc && \
+    npm install --production && \
+    rm -f .npmrc
 
-RUN npm install
-
+# second build
+FROM node:8.9.4
+COPY --from=base . .
 EXPOSE 4000
+USER node


### PR DESCRIPTION
Hello FSA.

In case your Docker image ever got out to the wild some how it might be worth using a multi-stage build to ensure your .npmrc file with the token that you pass into it during build time isn't exposed.  I presume it's just used to pull in the @slice-and-dice/fsa-rof package.

Reasoning behind doing a multi-stage build can be found in more detail [here](https://www.alexandraulsh.com/2018/06/25/docker-npmrc-security).