### PR TITLE
Correct column names in Partners table

### DIFF
--- a/src/db/migrations/v1.8.1-add-partnership-details.js
+++ b/src/db/migrations/v1.8.1-add-partnership-details.js
@@ -13,10 +13,10 @@ module.exports = {
       updatedAt: {
         type: Sequelize.DATE
       },
-      name: {
+      partner_name: {
         type: Sequelize.STRING
       },
-      is_primary_contact: {
+      partner_is_primary_contact: {
         type: Sequelize.BOOLEAN
       },
       operatorId: {


### PR DESCRIPTION
Update migration scripts to create columns with the correct names in the partners table