### PR TITLE
prevent in-memory LC config storage

### DIFF
--- a/src/connectors/configDb/configDb.connector.js
+++ b/src/connectors/configDb/configDb.connector.js
@@ -113,11 +113,6 @@ const getAllLocalCouncilConfig = async () => {
   return allLcConfigData;
 };
 
-const clearLcConfigCache = () => {
-  allLcConfigData = [];
-  return allLcConfigData;
-};
-
 const clearMongoConnection = () => {
   client = undefined;
   configDB = undefined;
@@ -131,7 +126,6 @@ const addDeletedId = async id => {
 
 module.exports = {
   getAllLocalCouncilConfig,
-  clearLcConfigCache,
   clearMongoConnection,
   addDeletedId,
   getConfigVersion

--- a/src/connectors/configDb/configDb.connector.js
+++ b/src/connectors/configDb/configDb.connector.js
@@ -7,7 +7,7 @@ const { statusEmitter } = require("../../services/statusEmitter.service");
 let client = undefined;
 let configDB = undefined;
 
-let allLcConfigData = [];
+let allLcConfigData;
 
 const establishConnectionToMongo = async collectionName => {
   if (process.env.DOUBLE_MODE === "true") {
@@ -76,38 +76,32 @@ const getAllLocalCouncilConfig = async () => {
     "getAllLocalCouncilConfig"
   );
 
-  if (allLcConfigData.length === 0) {
-    try {
-      const lcConfigCollection = await establishConnectionToMongo("lcConfig");
-      const allLcConfigDataCursor = await lcConfigCollection.find({});
-      allLcConfigData = allLcConfigDataCursor.toArray();
+  try {
+    const lcConfigCollection = await establishConnectionToMongo("lcConfig");
+    const allLcConfigDataCursor = await lcConfigCollection.find({});
+    allLcConfigData = allLcConfigDataCursor.toArray();
 
-      statusEmitter.emit("incrementCount", "getConfigFromDbSucceeded");
-      statusEmitter.emit(
-        "setStatus",
-        "mostRecentGetConfigFromDbSucceeded",
-        true
-      );
-    } catch (err) {
-      statusEmitter.emit("incrementCount", "getConfigFromDbFailed");
-      statusEmitter.emit(
-        "setStatus",
-        "mostRecentGetConfigFromDbSucceeded",
-        false
-      );
-      logEmitter.emit(
-        "functionFail",
-        "configDb.connector",
-        "getAllLocalCouncilConfig",
-        err
-      );
+    statusEmitter.emit("incrementCount", "getConfigFromDbSucceeded");
+    statusEmitter.emit("setStatus", "mostRecentGetConfigFromDbSucceeded", true);
+  } catch (err) {
+    statusEmitter.emit("incrementCount", "getConfigFromDbFailed");
+    statusEmitter.emit(
+      "setStatus",
+      "mostRecentGetConfigFromDbSucceeded",
+      false
+    );
+    logEmitter.emit(
+      "functionFail",
+      "configDb.connector",
+      "getAllLocalCouncilConfig",
+      err
+    );
 
-      const newError = new Error();
-      newError.name = "mongoConnectionError";
-      newError.message = err.message;
+    const newError = new Error();
+    newError.name = "mongoConnectionError";
+    newError.message = err.message;
 
-      throw newError;
-    }
+    throw newError;
   }
 
   logEmitter.emit(

--- a/src/connectors/configDb/configDb.connector.test.js
+++ b/src/connectors/configDb/configDb.connector.test.js
@@ -5,7 +5,6 @@ const mongodb = require("mongodb");
 const {
   getAllLocalCouncilConfig,
   getConfigVersion,
-  clearLcConfigCache,
   clearMongoConnection,
   addDeletedId
 } = require("./configDb.connector");
@@ -69,74 +68,68 @@ describe("Function: getConfigVersion", () => {
 });
 
 describe("Function: getLocalCouncilDetails", () => {
-  describe("given the request has not yet been run during this process (empty cache)", () => {
-    describe("given the request throws an error", () => {
-      beforeEach(async () => {
-        process.env.DOUBLE_MODE = false;
-        clearLcConfigCache();
-        clearMongoConnection();
-        mongodb.MongoClient.connect.mockImplementation(() => {
-          throw new Error("example mongo error");
-        });
-
-        try {
-          await getAllLocalCouncilConfig();
-        } catch (err) {
-          result = err;
-        }
+  describe("given the request throws an error", () => {
+    beforeEach(async () => {
+      process.env.DOUBLE_MODE = false;
+      clearMongoConnection();
+      mongodb.MongoClient.connect.mockImplementation(() => {
+        throw new Error("example mongo error");
       });
 
-      describe("when the error shows that the connection has failed", () => {
-        it("should throw mongoConnectionError error", () => {
-          expect(result.name).toBe("mongoConnectionError");
-          expect(result.message).toBe("example mongo error");
-        });
-      });
+      try {
+        await getAllLocalCouncilConfig();
+      } catch (err) {
+        result = err;
+      }
     });
 
-    describe("given the request is successful", () => {
-      beforeEach(() => {
-        process.env.DOUBLE_MODE = false;
-        clearLcConfigCache();
-        clearMongoConnection();
-        mongodb.MongoClient.connect.mockImplementation(() => ({
-          db: () => ({
-            collection: () => ({
-              find: () => ({ toArray: () => mockLocalCouncilConfig })
-            })
+    describe("when the error shows that the connection has failed", () => {
+      it("should throw mongoConnectionError error", () => {
+        expect(result.name).toBe("mongoConnectionError");
+        expect(result.message).toBe("example mongo error");
+      });
+    });
+  });
+
+  describe("given the request is successful", () => {
+    beforeEach(() => {
+      process.env.DOUBLE_MODE = false;
+      clearMongoConnection();
+      mongodb.MongoClient.connect.mockImplementation(() => ({
+        db: () => ({
+          collection: () => ({
+            find: () => ({ toArray: () => mockLocalCouncilConfig })
           })
-        }));
-      });
-
-      it("should return the data from the find() response", async () => {
-        await expect(getAllLocalCouncilConfig()).resolves.toEqual(
-          mockLocalCouncilConfig
-        );
-      });
+        })
+      }));
     });
 
-    describe("when running in double mode", () => {
-      beforeEach(() => {
-        process.env.DOUBLE_MODE = true;
-        clearLcConfigCache();
-        clearMongoConnection();
-        lcConfigCollectionDouble.find.mockImplementation(() => ({
-          toArray: () => mockLocalCouncilConfig
-        }));
-      });
+    it("should return the data from the find() response", async () => {
+      await expect(getAllLocalCouncilConfig()).resolves.toEqual(
+        mockLocalCouncilConfig
+      );
+    });
+  });
 
-      it("should resolve with the data from the double's find() response", async () => {
-        await expect(getAllLocalCouncilConfig("hi")).resolves.toEqual(
-          mockLocalCouncilConfig
-        );
-      });
+  describe("when running in double mode", () => {
+    beforeEach(() => {
+      process.env.DOUBLE_MODE = true;
+      clearMongoConnection();
+      lcConfigCollectionDouble.find.mockImplementation(() => ({
+        toArray: () => mockLocalCouncilConfig
+      }));
+    });
+
+    it("should resolve with the data from the double's find() response", async () => {
+      await expect(getAllLocalCouncilConfig("hi")).resolves.toEqual(
+        mockLocalCouncilConfig
+      );
     });
   });
 
   describe("given the request is run more than once during this process (populated cache)", () => {
     beforeEach(() => {
       process.env.DOUBLE_MODE = false;
-      clearLcConfigCache();
       clearMongoConnection();
       mongodb.MongoClient.connect.mockClear();
       mongodb.MongoClient.connect.mockImplementation(() => ({
@@ -150,7 +143,6 @@ describe("Function: getLocalCouncilDetails", () => {
 
     it("returns the correct value", async () => {
       // clear the cache
-      clearLcConfigCache();
       clearMongoConnection();
 
       // run one request
@@ -166,7 +158,6 @@ describe("Function: getLocalCouncilDetails", () => {
 
     it("does not call the mongo connection function on the second function call", async () => {
       // clear the cache
-      clearLcConfigCache();
       clearMongoConnection();
 
       // run one request
@@ -194,9 +185,7 @@ describe("Function: getLocalCouncilDetails", () => {
     });
 
     it("should have called the connect function only once", async () => {
-      clearLcConfigCache();
       await getAllLocalCouncilConfig();
-      clearLcConfigCache();
       await getAllLocalCouncilConfig();
 
       expect(mongodb.MongoClient.connect).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Prevent LC configuration to be stored in a variable and re-used; force to always obtain up-do-date configuration from database