### PR TITLE
configdb-seed update for non-integrated LAs

### DIFF
--- a/src/connectors/configDb/configDb-seed/questions/lcConfigquestions.js
+++ b/src/connectors/configDb/configDb-seed/questions/lcConfigquestions.js
@@ -59,19 +59,22 @@ const localCouncil = [
     env: ["production"],
     type: "input",
     name: "SEED_TASCOMI_URL_LC",
-    message: "Enter the real Tascomi API URL for the new local council"
+    message:
+      "Enter the real Tascomi API URL for the new local council (leave blank if not integrated)"
   },
   {
     env: ["production"],
     type: "input",
     name: "SEED_TASCOMI_PUBLIC_KEY_LC",
-    message: "Enter the real Tascomi PUBLIC key for the new local council"
+    message:
+      "Enter the real Tascomi PUBLIC key for the new local council (leave blank if not integrated)"
   },
   {
     env: ["production"],
     type: "input",
     name: "SEED_TASCOMI_PRIVATE_KEY_LC",
-    message: "Enter the real Tascomi PRIVATE key for the new local council"
+    message:
+      "Enter the real Tascomi PRIVATE key for the new local council (leave blank if not integrated)"
   }
 ];
 

--- a/src/connectors/configDb/configDb-seed/templates/lcConfig.template.js
+++ b/src/connectors/configDb/configDb-seed/templates/lcConfig.template.js
@@ -12,20 +12,23 @@ const localCouncilTemplate = (seedData, env) => ({
   local_council_phone_number:
     env === "production" ? seedData.SEED_LC_PHONE_NUMBER : "01234 567890",
   local_council_url: seedData.SEED_LC_URL,
-  auth: {
-    url:
-      env === "production"
-        ? seedData.SEED_TASCOMI_URL_LC
-        : seedData.SEED_TASCOMI_URL_DEV,
-    public_key:
-      env === "production"
-        ? seedData.SEED_TASCOMI_PUBLIC_KEY_LC
-        : seedData.SEED_TASCOMI_PUBLIC_KEY_DEV,
-    private_key:
-      env === "production"
-        ? seedData.SEED_TASCOMI_PRIVATE_KEY_LC
-        : seedData.SEED_TASCOMI_PRIVATE_KEY_DEV
-  }
+  auth:
+    seedData.SEED_TASCOMI_PUBLIC_KEY_LC && seedData.SEED_TASCOMI_PRIVATE_KEY_LC
+      ? {
+          url:
+            env === "production"
+              ? seedData.SEED_TASCOMI_URL_LC
+              : seedData.SEED_TASCOMI_URL_DEV,
+          public_key:
+            env === "production"
+              ? seedData.SEED_TASCOMI_PUBLIC_KEY_LC
+              : seedData.SEED_TASCOMI_PUBLIC_KEY_DEV,
+          private_key:
+            env === "production"
+              ? seedData.SEED_TASCOMI_PRIVATE_KEY_LC
+              : seedData.SEED_TASCOMI_PRIVATE_KEY_DEV
+        }
+      : null
 });
 
 module.exports = localCouncilTemplate;


### PR DESCRIPTION
-lcConfig question updated to advise to leave integration details blank for non-integrated LAs
-auth object set to NULL when public & private key pair is not specified