### PR TITLE
Jest24 coverage uncollected

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     events: "<rootDir>/src/__mocks__/events.js"
   },
   collectCoverageFrom: [
-    "**/*.{js}",
+    "**/*.js",
     "!**/node_modules/**",
     "!**/vendor/**",
     "!**/coverage/**",

--- a/src/services/status.service.test.js
+++ b/src/services/status.service.test.js
@@ -92,6 +92,27 @@ describe("Function: status.service setStatus()", () => {
     });
   });
 
+  describe("given sendSingleEmail throws error", () => {
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      getStoredStatus.mockImplementation(() => ({}));
+      updateStoredStatus.mockImplementation(() => "new value");
+      getEmailDistribution.mockImplementation(() => ["test@test.com"]);
+      sendSingleEmail.mockImplementation(() => {
+        throw new Error("cannot send email");
+      });
+      try {
+        await setStatus("newStatusItem", "new value");
+      } catch (err) {
+        result = err;
+      }
+    });
+
+    it("should throw an error", () => {
+      expect(result.message).toBe("cannot send email");
+    });
+  });
+
   describe("given a the supplied statusName already exists with a diffrent value", () => {
     beforeEach(async () => {
       jest.clearAllMocks();


### PR DESCRIPTION
- Fix jest config, so that it collects coverage just as it was prior to migration to v24
- Add test for status.service to meet coverage threshold of 100%