### PR TITLE
Extend back end cache and store status

### DIFF
--- a/src/api/registration/registration.controller.js
+++ b/src/api/registration/registration.controller.js
@@ -12,8 +12,7 @@ const {
 const { sendNotifications } = require("../../services/notifications.service");
 
 const {
-  cacheRegistration,
-  updateCompletedInCache
+  cacheRegistration
 } = require("../../connectors/cacheDb/cacheDb.connector");
 
 const {
@@ -69,8 +68,7 @@ const createNewRegistration = async (
     registration,
     lcContactConfig,
     {
-      completed: {
-        tascomi: undefined,
+      status: {
         registration: undefined,
         notifications: undefined
       }
@@ -92,12 +90,6 @@ const createNewRegistration = async (
         hygiene_council_code: hygieneCouncilCode
       }),
       localCouncilUrl
-    );
-  } else {
-    await updateCompletedInCache(
-      postRegistrationMetadata["fsa-rn"],
-      "tascomi",
-      "n/a"
     );
   }
 

--- a/src/api/registration/registration.controller.js
+++ b/src/api/registration/registration.controller.js
@@ -12,7 +12,8 @@ const {
 const { sendNotifications } = require("../../services/notifications.service");
 
 const {
-  cacheRegistration
+  cacheRegistration,
+  updateCompletedInCache
 } = require("../../connectors/cacheDb/cacheDb.connector");
 
 const {
@@ -59,17 +60,24 @@ const createNewRegistration = async (
     hygieneCouncilCode
   );
 
-  const completeRegistration = Object.assign(
+  const completeCacheRecord = Object.assign(
     {},
     {
       "fsa-rn": postRegistrationMetadata["fsa-rn"],
       reg_submission_date: postRegistrationMetadata.reg_submission_date
     },
     registration,
-    lcContactConfig
+    lcContactConfig,
+    {
+      completed: {
+        tascomi: undefined,
+        registration: undefined,
+        notifications: undefined
+      }
+    }
   );
 
-  cacheRegistration(completeRegistration);
+  cacheRegistration(completeCacheRecord);
 
   const combinedResponse = Object.assign({}, postRegistrationMetadata, {
     lc_config: lcContactConfig
@@ -84,6 +92,12 @@ const createNewRegistration = async (
         hygiene_council_code: hygieneCouncilCode
       }),
       localCouncilUrl
+    );
+  } else {
+    await updateCompletedInCache(
+      postRegistrationMetadata["fsa-rn"],
+      "tascomi",
+      "n/a"
     );
   }
 

--- a/src/api/registration/registration.controller.js
+++ b/src/api/registration/registration.controller.js
@@ -37,8 +37,6 @@ const createNewRegistration = async (
     throw new Error("registration is undefined");
   }
 
-  cacheRegistration(registration);
-
   const errors = validate(registration);
   if (errors.length) {
     const err = new Error();
@@ -60,6 +58,18 @@ const createNewRegistration = async (
   const postRegistrationMetadata = await getRegistrationMetaData(
     hygieneCouncilCode
   );
+
+  const completeRegistration = Object.assign(
+    {},
+    {
+      "fsa-rn": postRegistrationMetadata["fsa-rn"],
+      reg_submission_date: postRegistrationMetadata.reg_submission_date
+    },
+    registration,
+    lcContactConfig
+  );
+
+  cacheRegistration(completeRegistration);
 
   const combinedResponse = Object.assign({}, postRegistrationMetadata, {
     lc_config: lcContactConfig

--- a/src/api/registration/registration.controller.test.js
+++ b/src/api/registration/registration.controller.test.js
@@ -17,7 +17,8 @@ jest.mock("../../services/notifications.service", () => ({
 }));
 
 jest.mock("../../connectors/cacheDb/cacheDb.connector", () => ({
-  cacheRegistration: jest.fn()
+  cacheRegistration: jest.fn(),
+  updateCompletedInCache: jest.fn()
 }));
 
 jest.mock("../../connectors/configDb/configDb.connector", () => ({
@@ -173,7 +174,14 @@ describe("registration controller", () => {
               reg_submission_date: postRegistrationMetadata.reg_submission_date
             },
             testRegistration,
-            exampleLcConfig
+            exampleLcConfig,
+            {
+              completed: {
+                tascomi: undefined,
+                registration: undefined,
+                notifications: undefined
+              }
+            }
           );
           expect(cacheRegistration).toHaveBeenLastCalledWith(expectedToCache);
         });

--- a/src/api/registration/registration.controller.test.js
+++ b/src/api/registration/registration.controller.test.js
@@ -176,8 +176,7 @@ describe("registration controller", () => {
             testRegistration,
             exampleLcConfig,
             {
-              completed: {
-                tascomi: undefined,
+              status: {
                 registration: undefined,
                 notifications: undefined
               }

--- a/src/api/registration/registration.service.js
+++ b/src/api/registration/registration.service.js
@@ -72,7 +72,7 @@ const saveRegistration = async (registration, fsa_rn, council) => {
     }
 
     const metadata = await createMetadata(registration.metadata, reg.id);
-    updateStatusInCache(fsa_rn, "registration", true);
+    await updateStatusInCache(fsa_rn, "registration", true);
     statusEmitter.emit("incrementCount", "storeRegistrationsInDbSucceeded");
     statusEmitter.emit(
       "setStatus",
@@ -94,7 +94,7 @@ const saveRegistration = async (registration, fsa_rn, council) => {
       metadataId: metadata.id
     };
   } catch (err) {
-    updateStatusInCache(fsa_rn, "registration", false);
+    await updateStatusInCache(fsa_rn, "registration", false);
     statusEmitter.emit("incrementCount", "storeRegistrationsInDbFailed");
     statusEmitter.emit(
       "setStatus",

--- a/src/api/registration/registration.service.js
+++ b/src/api/registration/registration.service.js
@@ -35,7 +35,7 @@ const {
 } = require("../../connectors/configDb/configDb.connector");
 
 const {
-  updateCompletedInCache
+  updateStatusInCache
 } = require("../../connectors/cacheDb/cacheDb.connector");
 
 const { logEmitter } = require("../../services/logging.service");
@@ -72,7 +72,7 @@ const saveRegistration = async (registration, fsa_rn, council) => {
     }
 
     const metadata = await createMetadata(registration.metadata, reg.id);
-    updateCompletedInCache(fsa_rn, "registration", "success");
+    updateStatusInCache(fsa_rn, "registration", true);
     statusEmitter.emit("incrementCount", "storeRegistrationsInDbSucceeded");
     statusEmitter.emit(
       "setStatus",
@@ -94,7 +94,7 @@ const saveRegistration = async (registration, fsa_rn, council) => {
       metadataId: metadata.id
     };
   } catch (err) {
-    updateCompletedInCache(fsa_rn, "registration", "failure");
+    updateStatusInCache(fsa_rn, "registration", false);
     statusEmitter.emit("incrementCount", "storeRegistrationsInDbFailed");
     statusEmitter.emit(
       "setStatus",
@@ -206,11 +206,8 @@ const sendTascomiRegistration = async (
       err.name = "tascomiRefNumber";
       throw err;
     }
-    updateCompletedInCache(
-      postRegistrationMetadata["fsa-rn"],
-      "tascomi",
-      "success"
-    );
+    updateStatusInCache(postRegistrationMetadata["fsa-rn"], "tascomi", true);
+
     logEmitter.emit(
       "functionSuccess",
       "registration.service",
@@ -218,11 +215,7 @@ const sendTascomiRegistration = async (
     );
     return response;
   } catch (err) {
-    updateCompletedInCache(
-      postRegistrationMetadata["fsa_rn"],
-      "tascomi",
-      "failure"
-    );
+    updateStatusInCache(postRegistrationMetadata["fsa_rn"], "tascomi", false);
     logEmitter.emit(
       "functionFail",
       "registrationService",

--- a/src/api/registration/registration.service.js
+++ b/src/api/registration/registration.service.js
@@ -34,6 +34,10 @@ const {
   addDeletedId
 } = require("../../connectors/configDb/configDb.connector");
 
+const {
+  updateCompletedInCache
+} = require("../../connectors/cacheDb/cacheDb.connector");
+
 const { logEmitter } = require("../../services/logging.service");
 const { statusEmitter } = require("../../services/statusEmitter.service");
 
@@ -68,7 +72,7 @@ const saveRegistration = async (registration, fsa_rn, council) => {
     }
 
     const metadata = await createMetadata(registration.metadata, reg.id);
-
+    updateCompletedInCache(fsa_rn, "registration", "success");
     statusEmitter.emit("incrementCount", "storeRegistrationsInDbSucceeded");
     statusEmitter.emit(
       "setStatus",
@@ -90,6 +94,7 @@ const saveRegistration = async (registration, fsa_rn, council) => {
       metadataId: metadata.id
     };
   } catch (err) {
+    updateCompletedInCache(fsa_rn, "registration", "failure");
     statusEmitter.emit("incrementCount", "storeRegistrationsInDbFailed");
     statusEmitter.emit(
       "setStatus",
@@ -201,6 +206,11 @@ const sendTascomiRegistration = async (
       err.name = "tascomiRefNumber";
       throw err;
     }
+    updateCompletedInCache(
+      postRegistrationMetadata["fsa-rn"],
+      "tascomi",
+      "success"
+    );
     logEmitter.emit(
       "functionSuccess",
       "registration.service",
@@ -208,6 +218,11 @@ const sendTascomiRegistration = async (
     );
     return response;
   } catch (err) {
+    updateCompletedInCache(
+      postRegistrationMetadata["fsa_rn"],
+      "tascomi",
+      "failure"
+    );
     logEmitter.emit(
       "functionFail",
       "registrationService",

--- a/src/connectors/cacheDb/cacheDb.connector.js
+++ b/src/connectors/cacheDb/cacheDb.connector.js
@@ -85,7 +85,7 @@ const updateStatusInCache = async (fsa_rn, property, value) => {
   logEmitter.emit("functionCall", "cacheDb.connector", "updateStatusInCache");
   try {
     const cachedRegistrations = await establishConnectionToMongo();
-    let status = await getStatus(cachedRegistrations, fsa_rn);
+    const status = await getStatus(cachedRegistrations, fsa_rn);
 
     status[property] = {
       time: getDate(),
@@ -161,9 +161,9 @@ const updateNotificationOnSent = async (
   );
   try {
     const cachedRegistrations = await establishConnectionToMongo();
-    let status = await getStatus(cachedRegistrations, fsa_rn);
+    const status = await getStatus(cachedRegistrations, fsa_rn);
 
-    let index = status.notifications.findIndex(
+    const index = status.notifications.findIndex(
       ({ type, address }) =>
         type === notificationType && address === notificationAddress
     );
@@ -218,7 +218,7 @@ const addNotificationToStatus = async (fsa_rn, emailsToSend) => {
   );
   try {
     const cachedRegistrations = await establishConnectionToMongo();
-    let status = await getStatus(cachedRegistrations, fsa_rn);
+    const status = await getStatus(cachedRegistrations, fsa_rn);
 
     status.notifications = [];
     for (let index in emailsToSend) {

--- a/src/connectors/cacheDb/cacheDb.connector.js
+++ b/src/connectors/cacheDb/cacheDb.connector.js
@@ -82,7 +82,11 @@ const cacheRegistration = async registration => {
  * @param {string} value The value for the result
  */
 const updateCompletedInCache = async (fsa_rn, property, value) => {
-  logEmitter.emit("functionCall", "cacheDb.connector", "updateCache");
+  logEmitter.emit(
+    "functionCall",
+    "cacheDb.connector",
+    "updateCompletedInCache"
+  );
   try {
     const cachedRegistrations = await establishConnectionToMongo();
     let cachedRegistration = await cachedRegistrations.findOne({
@@ -101,21 +105,30 @@ const updateCompletedInCache = async (fsa_rn, property, value) => {
         $set: { completed: newCompleted }
       }
     );
-    statusEmitter.emit("incrementCount", "updateRegistrationsInCacheSucceeded");
+    statusEmitter.emit("incrementCount", "updateCompletedInCacheSucceeded");
     statusEmitter.emit(
       "setStatus",
-      "mostRecentUpdateRegistrationInCacheSucceeded",
+      "mostRecentUpdateCompletedInCacheSucceeded",
       true
     );
-    logEmitter.emit("functionSuccess", "cacheDb.connector", "updateCache");
+    logEmitter.emit(
+      "functionSuccess",
+      "cacheDb.connector",
+      "updateCompletedInCache"
+    );
   } catch (err) {
-    statusEmitter.emit("incrementCount", "updateRegistrationsInCacheFailed");
+    statusEmitter.emit("incrementCount", "updateCompletedInCacheFailed");
     statusEmitter.emit(
       "setStatus",
-      "mostRecentUpdateRegistrationInCacheSucceeded",
+      "mostRecentUpdateCompletedInCacheSucceeded",
       false
     );
-    logEmitter.emit("functionFail", "cacheDb.connector", "updateCache", err);
+    logEmitter.emit(
+      "functionFail",
+      "cacheDb.connector",
+      "updateCompletedInCache",
+      err
+    );
 
     const newError = new Error();
     newError.name = "mongoConnectionError";
@@ -162,11 +175,25 @@ const updateNotificationOnCompleted = async (
         $set: { completed: newCompleted }
       }
     );
-  } catch (err) {
-    statusEmitter.emit("incrementCount", "updateRegistrationsInCacheFailed");
+    statusEmitter.emit(
+      "incrementCount",
+      "UpdateNotificationOnCompletedSucceeded"
+    );
     statusEmitter.emit(
       "setStatus",
-      "mostRecentUpdateRegistrationInCacheSucceeded",
+      "mostRecentUpdateNotificationOnCompletedSucceeded",
+      true
+    );
+    logEmitter.emit(
+      "functionSuccess",
+      "cacheDb.connector",
+      "updateNotificationOnCompleted"
+    );
+  } catch (err) {
+    statusEmitter.emit("incrementCount", "updateNotificationOnCompletedFailed");
+    statusEmitter.emit(
+      "setStatus",
+      "mostRecentUpdateNotificationOnCompletedSucceeded",
       false
     );
     logEmitter.emit(
@@ -215,11 +242,23 @@ const addNotificationToCompleted = async (fsa_rn, emailsToSend) => {
       { "fsa-rn": fsa_rn },
       { $set: { completed: newCompleted } }
     );
-  } catch (err) {
-    statusEmitter.emit("incrementCount", "updateRegistrationsInCacheFailed");
+
+    statusEmitter.emit("incrementCount", "addNotificationToCompletedSucceeded");
     statusEmitter.emit(
       "setStatus",
-      "mostRecentUpdateRegistrationInCacheSucceeded",
+      "mostRecentAddNotificationToCompletedSucceeded",
+      true
+    );
+    logEmitter.emit(
+      "functionSuccess",
+      "cacheDb.connector",
+      "addNotificationToCompleted"
+    );
+  } catch (err) {
+    statusEmitter.emit("incrementCount", "addNotificationToCompletedFailed");
+    statusEmitter.emit(
+      "setStatus",
+      "mostRecentAddNotificationToCompletedSucceeded",
       false
     );
     logEmitter.emit(

--- a/src/connectors/cacheDb/cacheDb.connector.js
+++ b/src/connectors/cacheDb/cacheDb.connector.js
@@ -141,7 +141,7 @@ const updateStatus = async (cachedRegistrations, fsa_rn, newStatus) => {
       $set: { status: newStatus }
     }
   );
-}
+};
 
 /**
  * Updates a specific notification when sent, finding the notification status from the type and address and updating the time and result fields

--- a/src/connectors/cacheDb/cacheDb.connector.test.js
+++ b/src/connectors/cacheDb/cacheDb.connector.test.js
@@ -1,7 +1,10 @@
 const mongodb = require("mongodb");
 const {
   cacheRegistration,
-  clearMongoConnection
+  clearMongoConnection,
+  updateCompletedInCache,
+  updateNotificationOnCompleted,
+  addNotificationToCompleted
 } = require("./cacheDb.connector");
 
 jest.mock("mongodb");
@@ -14,88 +17,360 @@ describe("Connector: cacheDb", () => {
     jest.clearAllMocks();
   });
 
-  describe("given the request is successful", () => {
-    beforeEach(async () => {
-      process.env.DOUBLE_MODE = false;
-      clearMongoConnection();
-      mongodb.MongoClient.connect.mockImplementation(async () => ({
-        db: () => ({
-          collection: () => ({
-            insertOne: () => ({ insertedId: "764" })
+  describe("Function: cacheRegistration", () => {
+    describe("given the request is successful", () => {
+      beforeEach(async () => {
+        process.env.DOUBLE_MODE = false;
+        clearMongoConnection();
+        mongodb.MongoClient.connect.mockImplementation(async () => ({
+          db: () => ({
+            collection: () => ({
+              insertOne: () => ({ insertedId: "764" })
+            })
           })
-        })
-      }));
-      response = await cacheRegistration({ reg: "data" });
-    });
-
-    it("should return the response from the insertOne()", () => {
-      expect(response.insertedId).toBe("764");
-    });
-  });
-
-  describe("given the request throws an error", () => {
-    beforeEach(async () => {
-      process.env.DOUBLE_MODE = false;
-      clearMongoConnection();
-      mongodb.MongoClient.connect.mockImplementation(() => ({
-        db: () => ({
-          collection: () => ({
-            insertOne: () => {
-              throw new Error("Example mongo error");
-            }
-          })
-        })
-      }));
-      try {
+        }));
         response = await cacheRegistration({ reg: "data" });
-      } catch (err) {
-        response = err;
-      }
+      });
+
+      it("should return the response from the insertOne()", () => {
+        expect(response.insertedId).toBe("764");
+      });
     });
 
-    it("should catch the error", () => {
-      expect(response.message).toBe("Example mongo error");
+    describe("given the request throws an error", () => {
+      beforeEach(async () => {
+        process.env.DOUBLE_MODE = false;
+        clearMongoConnection();
+        mongodb.MongoClient.connect.mockImplementation(() => ({
+          db: () => ({
+            collection: () => ({
+              insertOne: () => {
+                throw new Error("Example mongo error");
+              }
+            })
+          })
+        }));
+        try {
+          response = await cacheRegistration({ reg: "data" });
+        } catch (err) {
+          response = err;
+        }
+      });
+
+      it("should catch the error", () => {
+        expect(response.message).toBe("Example mongo error");
+      });
+    });
+
+    describe("given two requests without clearing the mongo connection", () => {
+      beforeEach(async () => {
+        process.env.DOUBLE_MODE = false;
+        clearMongoConnection();
+        mongodb.MongoClient.connect.mockImplementation(async () => ({
+          db: () => ({
+            collection: () => ({
+              insertOne: () => ({ insertedId: "1000" })
+            })
+          })
+        }));
+
+        response = await cacheRegistration({ reg: "data" });
+
+        mongodb.MongoClient.connect.mockImplementation(async () => ({
+          db: () => ({
+            collection: () => ({
+              insertOne: () => ({ insertedId: "2000" })
+            })
+          })
+        }));
+
+        response = await cacheRegistration({ reg: "data" });
+      });
+
+      it("should have used the first mongo connnection both times", () => {
+        expect(response.insertedId).toBe("1000");
+      });
+    });
+
+    describe("when running in double mode", () => {
+      beforeEach(async () => {
+        process.env.DOUBLE_MODE = "true";
+        response = await cacheRegistration();
+      });
+
+      it("should resolve with the data from the double's insertOne()", async () => {
+        expect(response.insertedId).toBe("13478de349");
+      });
     });
   });
 
-  describe("given two requests without clearing the mongo connection", () => {
-    beforeEach(async () => {
-      process.env.DOUBLE_MODE = false;
-      clearMongoConnection();
-      mongodb.MongoClient.connect.mockImplementation(async () => ({
-        db: () => ({
-          collection: () => ({
-            insertOne: () => ({ insertedId: "1000" })
+  describe("Function: updateCompletedInCache", () => {
+    describe("When success", () => {
+      let result;
+      beforeEach(async () => {
+        process.env.DOUBLE_MODE = false;
+        clearMongoConnection();
+        mongodb.MongoClient.connect.mockImplementation(async () => ({
+          db: () => ({
+            collection: () => ({
+              findOne: () => ({ completed: { register: undefined } }),
+              updateOne: () => {}
+            })
           })
-        })
-      }));
+        }));
 
-      response = await cacheRegistration({ reg: "data" });
+        try {
+          await updateCompletedInCache("123", "123", "123");
+        } catch (err) {
+          result = err;
+        }
+      });
 
-      mongodb.MongoClient.connect.mockImplementation(async () => ({
-        db: () => ({
-          collection: () => ({
-            insertOne: () => ({ insertedId: "2000" })
-          })
-        })
-      }));
-
-      response = await cacheRegistration({ reg: "data" });
+      it("should have aclled this", () => {
+        expect(result).toBe(undefined);
+      });
     });
 
-    it("should have used the first mongo connnection both times", () => {
-      expect(response.insertedId).toBe("1000");
+    describe("When Failure", () => {
+      let result;
+      beforeEach(async () => {
+        process.env.DOUBLE_MODE = false;
+        clearMongoConnection();
+        mongodb.MongoClient.connect.mockImplementation(async () => ({
+          db: () => ({
+            collection: () => ({
+              findOne: () => ({ completed: { register: undefined } }),
+              updateOne: () => {
+                throw new Error("Example mongo error");
+              }
+            })
+          })
+        }));
+
+        try {
+          await updateCompletedInCache("123", "123", "123");
+        } catch (err) {
+          result = err;
+        }
+      });
+
+      it("Should throw an error", () => {
+        expect(result.message).toBe("Example mongo error");
+      });
+    });
+
+    describe("Function: updateNotificationOnCompleted", () => {
+      describe("When success", () => {
+        let result;
+        beforeEach(async () => {
+          process.env.DOUBLE_MODE = false;
+          clearMongoConnection();
+          mongodb.MongoClient.connect.mockImplementation(async () => ({
+            db: () => ({
+              collection: () => ({
+                findOne: () => ({
+                  completed: {
+                    notifications: [
+                      {
+                        type: "LC",
+                        address: "example@example.com",
+                        time: undefined,
+                        result: undefined
+                      }
+                    ]
+                  }
+                }),
+                updateOne: () => {}
+              })
+            })
+          }));
+
+          try {
+            await updateNotificationOnCompleted(
+              "123",
+              "LC",
+              "example@example.com",
+              "success"
+            );
+          } catch (err) {
+            result = err;
+          }
+        });
+
+        it("should have aclled this", () => {
+          expect(result).toBe(undefined);
+        });
+      });
+
+      describe("When Failure", () => {
+        let result;
+        beforeEach(async () => {
+          process.env.DOUBLE_MODE = false;
+          clearMongoConnection();
+          mongodb.MongoClient.connect.mockImplementation(async () => ({
+            db: () => ({
+              collection: () => ({
+                findOne: () => ({
+                  completed: {
+                    notifications: [
+                      {
+                        type: "LC",
+                        address: "example@example.com",
+                        time: undefined,
+                        result: undefined
+                      }
+                    ]
+                  }
+                }),
+                updateOne: () => {
+                  throw new Error("Example mongo error");
+                }
+              })
+            })
+          }));
+
+          try {
+            await updateNotificationOnCompleted(
+              "123",
+              "LC",
+              "example@example.com",
+              "failure"
+            );
+          } catch (err) {
+            result = err;
+          }
+        });
+
+        it("Should throw an error", () => {
+          expect(result.message).toBe("Example mongo error");
+        });
+      });
     });
   });
 
-  describe("when running in double mode", () => {
-    beforeEach(async () => {
-      process.env.DOUBLE_MODE = "true";
-      response = await cacheRegistration();
+  describe("Function: updateCompletedInCache", () => {
+    describe("When success", () => {
+      let result;
+      beforeEach(async () => {
+        process.env.DOUBLE_MODE = false;
+        clearMongoConnection();
+        mongodb.MongoClient.connect.mockImplementation(async () => ({
+          db: () => ({
+            collection: () => ({
+              findOne: () => ({ completed: { register: undefined } }),
+              updateOne: () => {}
+            })
+          })
+        }));
+
+        try {
+          await updateCompletedInCache("123", "123", "123");
+        } catch (err) {
+          result = err;
+        }
+      });
+
+      it("should have aclled this", () => {
+        expect(result).toBe(undefined);
+      });
     });
 
-    it("should resolve with the data from the double's insertOne()", async () => {
-      expect(response.insertedId).toBe("13478de349");
+    describe("When Failure", () => {
+      let result;
+      beforeEach(async () => {
+        process.env.DOUBLE_MODE = false;
+        clearMongoConnection();
+        mongodb.MongoClient.connect.mockImplementation(async () => ({
+          db: () => ({
+            collection: () => ({
+              findOne: () => ({ completed: { register: undefined } }),
+              updateOne: () => {
+                throw new Error("Example mongo error");
+              }
+            })
+          })
+        }));
+
+        try {
+          await updateCompletedInCache("123", "123", "123");
+        } catch (err) {
+          result = err;
+        }
+      });
+
+      it("Should throw an error", () => {
+        expect(result.message).toBe("Example mongo error");
+      });
+    });
+
+    describe("Function: addNotificationToCompleted", () => {
+      describe("When success", () => {
+        let result;
+        beforeEach(async () => {
+          process.env.DOUBLE_MODE = false;
+          clearMongoConnection();
+          mongodb.MongoClient.connect.mockImplementation(async () => ({
+            db: () => ({
+              collection: () => ({
+                findOne: () => ({
+                  completed: []
+                }),
+                updateOne: () => {}
+              })
+            })
+          }));
+
+          try {
+            await addNotificationToCompleted("123", [
+              {
+                type: "LC",
+                address: "example@example.com"
+              }
+            ]);
+          } catch (err) {
+            result = err;
+          }
+        });
+
+        it("should have aclled this", () => {
+          expect(result).toBe(undefined);
+        });
+      });
+
+      describe("When Failure", () => {
+        let result;
+        beforeEach(async () => {
+          process.env.DOUBLE_MODE = false;
+          clearMongoConnection();
+          mongodb.MongoClient.connect.mockImplementation(async () => ({
+            db: () => ({
+              collection: () => ({
+                findOne: () => ({
+                  completed: []
+                }),
+                updateOne: () => {
+                  throw new Error("Example mongo error");
+                }
+              })
+            })
+          }));
+
+          try {
+            await addNotificationToCompleted("123", [
+              {
+                type: "LC",
+                address: "example@example.com"
+              }
+            ]);
+          } catch (err) {
+            result = err;
+          }
+        });
+
+        it("Should throw an error", () => {
+          expect(result.message).toBe("Example mongo error");
+        });
+      });
     });
   });
 });

--- a/src/connectors/cacheDb/cacheDb.connector.test.js
+++ b/src/connectors/cacheDb/cacheDb.connector.test.js
@@ -2,9 +2,9 @@ const mongodb = require("mongodb");
 const {
   cacheRegistration,
   clearMongoConnection,
-  updateCompletedInCache,
-  updateNotificationOnCompleted,
-  addNotificationToCompleted
+  updateStatusInCache,
+  updateNotificationOnSent,
+  addNotificationToStatus
 } = require("./cacheDb.connector");
 
 jest.mock("mongodb");
@@ -113,14 +113,14 @@ describe("Connector: cacheDb", () => {
         mongodb.MongoClient.connect.mockImplementation(async () => ({
           db: () => ({
             collection: () => ({
-              findOne: () => ({ completed: { register: undefined } }),
+              findOne: () => ({ status: { register: undefined } }),
               updateOne: () => {}
             })
           })
         }));
 
         try {
-          await updateCompletedInCache("123", "123", "123");
+          await updateStatusInCache("123", "123", "123");
         } catch (err) {
           result = err;
         }
@@ -139,7 +139,7 @@ describe("Connector: cacheDb", () => {
         mongodb.MongoClient.connect.mockImplementation(async () => ({
           db: () => ({
             collection: () => ({
-              findOne: () => ({ completed: { register: undefined } }),
+              findOne: () => ({ status: { register: undefined } }),
               updateOne: () => {
                 throw new Error("Example mongo error");
               }
@@ -148,7 +148,7 @@ describe("Connector: cacheDb", () => {
         }));
 
         try {
-          await updateCompletedInCache("123", "123", "123");
+          await updateStatusInCache("123", "123", "123");
         } catch (err) {
           result = err;
         }
@@ -169,13 +169,13 @@ describe("Connector: cacheDb", () => {
             db: () => ({
               collection: () => ({
                 findOne: () => ({
-                  completed: {
+                  status: {
                     notifications: [
                       {
                         type: "LC",
                         address: "example@example.com",
                         time: undefined,
-                        result: undefined
+                        sent: undefined
                       }
                     ]
                   }
@@ -186,12 +186,7 @@ describe("Connector: cacheDb", () => {
           }));
 
           try {
-            await updateNotificationOnCompleted(
-              "123",
-              "LC",
-              "example@example.com",
-              "success"
-            );
+            await updateNotificationOnSent("123", "LC", "example@example.com");
           } catch (err) {
             result = err;
           }
@@ -211,13 +206,13 @@ describe("Connector: cacheDb", () => {
             db: () => ({
               collection: () => ({
                 findOne: () => ({
-                  completed: {
+                  status: {
                     notifications: [
                       {
                         type: "LC",
                         address: "example@example.com",
                         time: undefined,
-                        result: undefined
+                        sent: undefined
                       }
                     ]
                   }
@@ -230,12 +225,7 @@ describe("Connector: cacheDb", () => {
           }));
 
           try {
-            await updateNotificationOnCompleted(
-              "123",
-              "LC",
-              "example@example.com",
-              "failure"
-            );
+            await updateNotificationOnSent("123", "LC", "example@example.com");
           } catch (err) {
             result = err;
           }
@@ -264,7 +254,7 @@ describe("Connector: cacheDb", () => {
         }));
 
         try {
-          await updateCompletedInCache("123", "123", "123");
+          await updateStatusInCache("123", "123", "123");
         } catch (err) {
           result = err;
         }
@@ -292,7 +282,7 @@ describe("Connector: cacheDb", () => {
         }));
 
         try {
-          await updateCompletedInCache("123", "123", "123");
+          await updateStatusInCache("123", "123", "123");
         } catch (err) {
           result = err;
         }
@@ -321,7 +311,7 @@ describe("Connector: cacheDb", () => {
           }));
 
           try {
-            await addNotificationToCompleted("123", [
+            await addNotificationToStatus("123", [
               {
                 type: "LC",
                 address: "example@example.com"
@@ -356,7 +346,7 @@ describe("Connector: cacheDb", () => {
           }));
 
           try {
-            await addNotificationToCompleted("123", [
+            await addNotificationToStatus("123", [
               {
                 type: "LC",
                 address: "example@example.com"

--- a/src/connectors/notify/notify.connector.js
+++ b/src/connectors/notify/notify.connector.js
@@ -2,24 +2,18 @@ const { NotifyClient } = require("notifications-node-client");
 const { notifyClientDouble } = require("./notify.double");
 const { NOTIFY_KEY } = require("../../config");
 const { logEmitter } = require("../../services/logging.service");
-const {
-  updateNotificationOnCompleted
-} = require("../cacheDb/cacheDb.connector");
-
 /**
  * Send a single email
  * @param {string} templateId The template Id for the relevant email in notify
  * @param {string} recipientEmail The email address for notifaction to be sent to
  * @param {object} flattenedData The data for the template properties
  * @param {object} pdfFile The pdf file to be sent with email
- * @param {object} updateCache The function to update the  notification status
  */
 const sendSingleEmail = async (
   templateId,
   recipientEmail,
   flattenedData,
-  pdfFile,
-  updateCache
+  pdfFile
 ) => {
   logEmitter.emit("functionCall", "notify.connector", "sendSingleEmail");
 
@@ -75,14 +69,6 @@ const sendSingleEmail = async (
 
     const notifyResponse = await notifyClient.sendEmail(...notifyArguments);
     const responseBody = notifyResponse.body;
-    if (updateCache) {
-      updateNotificationOnCompleted(
-        updateCache["fsa-rn"],
-        updateCache.type,
-        recipientEmail,
-        "Success"
-      );
-    }
     logEmitter.emit("functionSuccess", "notify.connector", "sendSingleEmail");
     return responseBody;
   } catch (err) {
@@ -106,14 +92,6 @@ const sendSingleEmail = async (
       "sendSingleEmail",
       newError
     );
-    if (updateCache) {
-      updateNotificationOnCompleted(
-        updateCache["fsa-rn"],
-        updateCache.type,
-        recipientEmail,
-        "Failure"
-      );
-    }
     throw newError;
   }
 };

--- a/src/connectors/notify/notify.connector.js
+++ b/src/connectors/notify/notify.connector.js
@@ -3,11 +3,20 @@ const { notifyClientDouble } = require("./notify.double");
 const { NOTIFY_KEY } = require("../../config");
 const { logEmitter } = require("../../services/logging.service");
 
+/**
+ * Send a single email
+ * @param {string} templateId The template Id for the relevant email in notify
+ * @param {string} recipientEmail The email address for notifaction to be sent to
+ * @param {object} flattenedData The data for the template properties
+ * @param {object} pdfFile The pdf file to be sent with email
+ * @param {function} updateCache The function to update the  notification status
+ */
 const sendSingleEmail = async (
   templateId,
   recipientEmail,
   flattenedData,
-  pdfFile
+  pdfFile,
+  updateCache
 ) => {
   logEmitter.emit("functionCall", "notify.connector", "sendSingleEmail");
 
@@ -63,6 +72,7 @@ const sendSingleEmail = async (
 
     const notifyResponse = await notifyClient.sendEmail(...notifyArguments);
     const responseBody = notifyResponse.body;
+    updateCache("Success");
     logEmitter.emit("functionSuccess", "notify.connector", "sendSingleEmail");
     return responseBody;
   } catch (err) {
@@ -86,6 +96,7 @@ const sendSingleEmail = async (
       "sendSingleEmail",
       newError
     );
+    updateCache("Failure");
     throw newError;
   }
 };

--- a/src/connectors/notify/notify.connector.test.js
+++ b/src/connectors/notify/notify.connector.test.js
@@ -1,12 +1,17 @@
 const { NotifyClient } = require("notifications-node-client");
 const { sendSingleEmail } = require("./notify.connector");
 const { notifyClientDouble } = require("./notify.double");
+const {
+  updateNotificationOnCompleted
+} = require("../cacheDb/cacheDb.connector");
 
 jest.mock("notifications-node-client");
 jest.mock("./notify.double");
+jest.mock("../cacheDb/cacheDb.connector");
 
 describe("Function: sendSingleEmail", () => {
   let mockNotifyClient;
+  let mockCacheDbConnector;
   const testTemplateId = "123456";
   const testRecipient = "email@email.com";
   const testPdfFile = "example pdf file";
@@ -41,6 +46,12 @@ describe("Function: sendSingleEmail", () => {
         prepareUpload: jest.fn()
       };
       NotifyClient.mockImplementation(() => mockNotifyClient);
+      mockCacheDbConnector = {
+        updateNotificationOnCompleted: jest.fn()
+      };
+      updateNotificationOnCompleted.mockImplementation(
+        () => mockCacheDbConnector.updateNotificationOnCompleted
+      );
     });
 
     it("Should resolve with the success message", async () => {
@@ -66,7 +77,41 @@ describe("Function: sendSingleEmail", () => {
           testRecipient,
           { personalisation: expectedFlattenedDataWithExists }
         );
+        expect(updateNotificationOnCompleted).not.toHaveBeenCalled();
       });
+    });
+  });
+  describe("given the request is successful with update cache", () => {
+    beforeEach(async () => {
+      process.env.DOUBLE_MODE = false;
+      jest.clearAllMocks();
+      mockNotifyClient = {
+        sendEmail: jest.fn(async () => {
+          return { body: "This is a success message from the notify client" };
+        }),
+        getTemplateById: jest.fn(() => testFetchedTemplate),
+        prepareUpload: jest.fn()
+      };
+      mockCacheDbConnector = {
+        updateNotificationOnCompleted: jest.fn()
+      };
+      NotifyClient.mockImplementation(() => mockNotifyClient);
+      updateNotificationOnCompleted.mockImplementation(
+        () => mockCacheDbConnector.updateNotificationOnCompleted
+      );
+    });
+    it("Should update the notification status", async () => {
+      return sendSingleEmail(...args, {
+        type: "LC",
+        "fsa-rn": "example"
+      }).then(() =>
+        expect(updateNotificationOnCompleted).toHaveBeenCalledWith(
+          "example",
+          "LC",
+          testRecipient,
+          "Success"
+        )
+      );
     });
   });
 
@@ -211,6 +256,48 @@ describe("Function: sendSingleEmail", () => {
     it("Should resolve with the success message", async () => {
       await expect(sendSingleEmail(...args)).resolves.toBe(
         "This is a success message from the notify client"
+      );
+    });
+  });
+
+  describe("given the request is throws error update cache", () => {
+    beforeEach(async () => {
+      mockNotifyClient = {
+        sendEmail: jest.fn(async () => {
+          const error = new Error();
+          error.statusCode = 400;
+          error.error = {
+            errors: [
+              {
+                error: "BadRequestError"
+              }
+            ]
+          };
+          error.message = "notify error";
+          throw error;
+        }),
+        prepareUpload: jest.fn(),
+        getTemplateById: jest.fn(() => testFetchedTemplate)
+      };
+      NotifyClient.mockImplementation(() => mockNotifyClient);
+      let mockCacheDbConnectora = {
+        updateNotificationOnCompleted: jest.fn()
+      };
+      updateNotificationOnCompleted.mockImplementation(
+        () => mockCacheDbConnectora.updateNotificationOnCompleted
+      );
+      sendSingleEmail(...args, {
+        type: "LC",
+        "fsa-rn": "example"
+      });
+    });
+    it("Should update the notification status", async () => {
+      //expect(result).toBeDefined();
+      expect(updateNotificationOnCompleted).toHaveBeenCalledWith(
+        "example",
+        "LC",
+        testRecipient,
+        "Failure"
       );
     });
   });

--- a/src/services/notifications.service.js
+++ b/src/services/notifications.service.js
@@ -9,8 +9,7 @@ const { statusEmitter } = require("./statusEmitter.service");
 const { sendSingleEmail } = require("../connectors/notify/notify.connector");
 const { pdfGenerator, transformDataForPdf } = require("./pdf.service");
 const {
-  addNotificationToCompleted,
-  updateNotificationOnCompleted
+  addNotificationToCompleted
 } = require("../connectors/cacheDb/cacheDb.connector");
 
 /**
@@ -143,13 +142,10 @@ const sendEmails = async (
         emailsToSend[index].address,
         data,
         fileToSend,
-        value =>
-          updateNotificationOnCompleted(
-            postRegistrationMetadata["fsa-rn"],
-            emailsToSend[index].type,
-            emailsToSend[index].address,
-            value
-          )
+        {
+          "fsa-rn": postRegistrationMetadata["fsa-rn"],
+          type: emailsToSend[index].type
+        }
       );
     }
     statusEmitter.emit("incrementCount", "emailNotificationsSucceeded");

--- a/src/services/notifications.service.js
+++ b/src/services/notifications.service.js
@@ -8,6 +8,10 @@ const { logEmitter } = require("./logging.service");
 const { statusEmitter } = require("./statusEmitter.service");
 const { sendSingleEmail } = require("../connectors/notify/notify.connector");
 const { pdfGenerator, transformDataForPdf } = require("./pdf.service");
+const {
+  addNotificationToCompleted,
+  updateNotificationOnCompleted
+} = require("../connectors/cacheDb/cacheDb.connector");
 
 /**
  * Function that converts the data into format for Notify and creates a new object
@@ -138,7 +142,14 @@ const sendEmails = async (
         emailsToSend[index].templateId,
         emailsToSend[index].address,
         data,
-        fileToSend
+        fileToSend,
+        value =>
+          updateNotificationOnCompleted(
+            postRegistrationMetadata["fsa-rn"],
+            emailsToSend[index].type,
+            emailsToSend[index].address,
+            value
+          )
       );
     }
     statusEmitter.emit("incrementCount", "emailNotificationsSucceeded");
@@ -212,6 +223,8 @@ const sendNotifications = async (
       templateId: configData.notify_template_keys.fd_feedback
     });
   }
+
+  addNotificationToCompleted(postRegistrationMetadata["fsa-rn"], emailsToSend);
 
   await sendEmails(
     emailsToSend,

--- a/src/services/notifications.service.js
+++ b/src/services/notifications.service.js
@@ -9,7 +9,8 @@ const { statusEmitter } = require("./statusEmitter.service");
 const { sendSingleEmail } = require("../connectors/notify/notify.connector");
 const { pdfGenerator, transformDataForPdf } = require("./pdf.service");
 const {
-  addNotificationToCompleted
+  addNotificationToStatus,
+  updateNotificationOnSent
 } = require("../connectors/cacheDb/cacheDb.connector");
 
 /**
@@ -147,6 +148,11 @@ const sendEmails = async (
           type: emailsToSend[index].type
         }
       );
+
+      updateNotificationOnSent(
+        postRegistrationMetadata["fsa-rn"],
+        emailsToSend[index].type
+      );
     }
     statusEmitter.emit("incrementCount", "emailNotificationsSucceeded");
     statusEmitter.emit(
@@ -220,7 +226,7 @@ const sendNotifications = async (
     });
   }
 
-  addNotificationToCompleted(postRegistrationMetadata["fsa-rn"], emailsToSend);
+  addNotificationToStatus(postRegistrationMetadata["fsa-rn"], emailsToSend);
 
   await sendEmails(
     emailsToSend,

--- a/src/services/notifications.service.test.js
+++ b/src/services/notifications.service.test.js
@@ -1,3 +1,4 @@
+jest.mock("../connectors/cacheDb/cacheDb.connector.js");
 jest.mock("../connectors/notify/notify.connector", () => ({
   sendSingleEmail: jest.fn()
 }));
@@ -8,6 +9,9 @@ jest.mock("./statusEmitter.service");
 const { pdfGenerator } = require("./pdf.service");
 
 const { sendSingleEmail } = require("../connectors/notify/notify.connector");
+const {
+  addNotificationToCompleted
+} = require("../connectors/cacheDb/cacheDb.connector.js");
 
 const {
   transformDataForNotify,
@@ -450,6 +454,7 @@ describe("Function: sendEmailOfType: ", () => {
       sendSingleEmail.mockImplementation(() => ({
         id: "123-456"
       }));
+      addNotificationToCompleted.mockImplementation();
       await sendNotifications(
         mockLcContactConfig,
         mockRegistrationData,

--- a/src/services/notifications.service.test.js
+++ b/src/services/notifications.service.test.js
@@ -10,7 +10,7 @@ const { pdfGenerator } = require("./pdf.service");
 
 const { sendSingleEmail } = require("../connectors/notify/notify.connector");
 const {
-  addNotificationToCompleted
+  addNotificationToStatus
 } = require("../connectors/cacheDb/cacheDb.connector.js");
 
 const {
@@ -454,7 +454,7 @@ describe("Function: sendEmailOfType: ", () => {
       sendSingleEmail.mockImplementation(() => ({
         id: "123-456"
       }));
-      addNotificationToCompleted.mockImplementation();
+      addNotificationToStatus.mockImplementation();
       await sendNotifications(
         mockLcContactConfig,
         mockRegistrationData,


### PR DESCRIPTION
- Reorder registration route to log further registration details such as FRN
- Store status of each of the tascomi, save registration and for every email sent into cache for error awareness.
